### PR TITLE
Shuttle Pathfinder (S.P.O.C.K.) Support

### DIFF
--- a/ModSupport/Benjee10_Orion/Benjee10_Orion.cfg
+++ b/ModSupport/Benjee10_Orion/Benjee10_Orion.cfg
@@ -101,6 +101,11 @@ Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous p
 //Tier 8 comms8
 
 //Tier 9 comms9
+@PART[benjee10_orion_opticalComms]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = comms9
+
+}
 
 //Tier 10 comms10
 
@@ -131,6 +136,11 @@ Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous p
 
 }
 @PART[benjee10_orion_auxThruster*]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = control9
+
+}
+@PART[benjee10_orion_starTracker]:AFTER[Benjee10_Orion] //
 {
 	@TechRequired = control9
 
@@ -197,6 +207,72 @@ Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous p
 	@TechRequired = landing9
 
 }
+@PART[benjee10_HLS_adapter]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_avionics]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_cargoBox]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_cargoRack]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_fuelCell]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_handrail1]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_handrail2]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_ladder]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_leg]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_mount]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_pod]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_tank]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+@PART[benjee10_HLS_tankHalf]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = landing9
+
+}
+
 //Tier 10 landing10
 
 //Tier 11 landing11
@@ -270,13 +346,29 @@ Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous p
 //Tier 7 solids7
 
 //Tier 8 solids8
+@PART[benjee10_SLS_boosterSepMotor]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = solids8
+
+}
 
 //Tier 9 solids9
-@PART[benjee10_SLS_boosterSepMotor]:AFTER[Benjee10_Orion] //
+@PART[benjee10_SLS_BOLE_booster]:AFTER[Benjee10_Orion] //
 {
 	@TechRequired = solids9
 
 }
+@PART[benjee10_SLS_BOLE_decoupler]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = solids9
+
+}
+@PART[benjee10_SLS_BOLE_sepMotor]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = solids9
+
+}
+
 //Tier 10 solids10
 
 //Tier 11 solids11
@@ -514,7 +606,7 @@ Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous p
 //Tier 8 solar8
 
 //Tier 9 solar9
-@PART[benjee10_orion_solar*]:AFTER[Benjee10_Orion] //
+@PART[benjee10_orion_solarArray]:AFTER[Benjee10_Orion] //
 {
 	@TechRequired = solar9
 
@@ -607,8 +699,53 @@ Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous p
 	@TechRequired = construction9
 
 }
+@PART[benjee10_orion_stageAdapter_3-125]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = construction9
+
+}
+@PART[benjee10_orion_stageAdapter_3-75]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = construction9
+
+}
+@PART[benjee10_orion_stageAdapter_2-5]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = construction9
+
+}
+@PART[benjee10_SLS_USA_fairingBase]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = construction9
+
+}
+@PART[benjee10_SLS_USA_fairing]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = construction9
+
+}
+@PART[benjee10_SLS_USA_cone]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = construction9
+
+}
+@PART[benjee10_SLS_LVSA]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = construction9
+
+}
+@PART[benjee10_SLS_fairing]:AFTER[Benjee10_Orion] //
+{
+	@TechRequired = construction9
+
+}
 
 //Tier 10 construction10
+@PARTUPGRADE[benjee10_SLS_EUS_composites]:AFTER[Benjee10_Orion] //
+{
+	@techRequired = construction10
+	
+}
 
 //Tier 11 construction11
 

--- a/ModSupport/Benjee10_stowaway/Benjee10_stowaway.cfg
+++ b/ModSupport/Benjee10_stowaway/Benjee10_stowaway.cfg
@@ -587,19 +587,19 @@ Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous p
 //Tier 8 capsules8
 
 //Tier 9 capsules9
-@PART[Benjee10_stowaway_Pod]:AFTER[Benjee10_stowaway] //
-{
-	@TechRequired = capsules9
-}
-
-@PART[Benjee10_stowaway_NoseCone]:AFTER[Benjee10_stowaway] //
-{
-	@TechRequired = capsules9
-}
 
 //Tier 10 capsules10
 
 //Tier 11 capsules11
+@PART[Benjee10_stowaway_Pod]:AFTER[Benjee10_stowaway] //
+{
+	@TechRequired = capsules11
+}
+
+@PART[Benjee10_stowaway_NoseCone]:AFTER[Benjee10_stowaway] //
+{
+	@TechRequired = capsules11
+}
 
 //////Space Station Parts (Both Structural and Crewed)  (spaceStations#)
 

--- a/ModSupport/Bluedog_DB/Bluedog_DB.cfg
+++ b/ModSupport/Bluedog_DB/Bluedog_DB.cfg
@@ -240,6 +240,26 @@
 	@TechRequired = comms5
 
 }
+@PART[bluedog_Surveyor_Omni1]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = comms5
+
+}
+@PART[bluedog_Surveyor_Omni2]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = comms5
+
+}
+@PART[bluedog_SurveyorOrbiter_Antenna]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = comms5
+
+}
+@PART[bluedog_SurveyorOrbiter_Omni]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = comms5
+
+}
 
 //Tier 6 comms6
 @PART[bluedog_GooLab_Antenna]:AFTER[Bluedog_DB] //
@@ -527,6 +547,41 @@
 
 }
 @PART[bluedog_Skylab_discone_antenna]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = comms8
+
+}
+@PART[bluedog_voyagerMarsLander_commandAntenna]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = comms8
+
+}
+@PART[bluedog_voyagerMarsLander_HGA]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = comms8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_HGA]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = comms8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_HGA_large]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = comms8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_LGA]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = comms8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_MGA]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = comms8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_relayAntenna]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = comms8
 
@@ -1244,6 +1299,11 @@
 	@TechRequired = control8
 
 }
+@PART[bluedog_voyagerMarsOrbiter_starTracker]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = control8
+
+}
 
 //Tier 9 control9
 
@@ -1473,6 +1533,17 @@
 	@TechRequired = probes5
 
 }
+@PART[bluedog_Surveyor_Core]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = probes5
+
+}
+@PART[bluedog_SurveyorOrbiter_Core]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = probes5
+
+}
+
 
 //Tier 6 probes6
 @PART[bluedog_Mariner_Bus]:AFTER[Bluedog_DB] //
@@ -1523,8 +1594,6 @@
 	@TechRequired = probes8
 
 }
-
-//Tier 9 probes9
 @PART[bluedog_voyagerMarsLander_core]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = probes8
@@ -1540,6 +1609,13 @@
 	@TechRequired = probes8
 
 }
+@PART[bluedog_voyagerMarsOrbiter_SM]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = probes8
+
+}
+
+//Tier 9 probes9
 
 //Tier 10 probes10
 
@@ -1592,6 +1668,11 @@
 
 }
 @PART[bluedog_Ranger_Lander_Leg]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing5
+
+}
+@PART[bluedog_Surveyor_Leg]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = landing5
 
@@ -2594,6 +2675,11 @@
 {
 	@techRequired = kerolox5
 }
+@PART[bluedog_Surveyor_Vernier]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = kerolox5
+
+}
 
 //Tier 6 kerolox6
 @PARTUPGRADE[bluedog_Atlas2]:AFTER[Bluedog_DB]
@@ -2796,6 +2882,7 @@
 	@TechRequired = hypergol5
 
 }
+
 //Tier 6 hypergol6
 @PART[bluedog_Mariner_Midcourse_Engine]:AFTER[Bluedog_DB] //
 {
@@ -3635,6 +3722,12 @@
 	@TechRequired = reactors8
 
 }
+@PART[bluedog_voyagerMarsLander_RTG]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = reactors8
+
+}
+
 //Tier 9 reactors9
 
 //Tier 10 reactors10
@@ -3731,6 +3824,11 @@
 //Tier 4 electrics4
 
 //Tier 5 electrics5
+@PART[bluedog_Surveyor_AuxBattery]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = electrics3
+
+}
 
 //Tier 6 electrics6
 @PART[bluedog_ATDA_Battery]:AFTER[Bluedog_DB] //
@@ -3923,6 +4021,16 @@
 	@TechRequired = solar5
 
 }
+@PART[bluedog_Surveyor_SolarAntenna]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = solar5
+
+}
+@PART[bluedog_SurveyorOrbiter_Solar]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = solar5
+
+}
 
 //Tier 6 solar6
 @PART[bluedog_GooLab_Solar]:AFTER[Bluedog_DB] //
@@ -4041,6 +4149,16 @@
 
 }
 @PART[bluedog_skylab_solarWing]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = solar8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_solarFlat]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = solar8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_annularSolarPanel]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = solar8
 
@@ -4843,6 +4961,11 @@
 	@TechRequired = construction5
 
 }
+@PART[bluedog_Surveyor_Adapter]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = construction5
+
+}
 
 //Tier 6 construction6
 @PART[BDB_FASAlaunchTower]:AFTER[Bluedog_DB] //
@@ -5578,6 +5701,11 @@
 
 }
 @PART[bluedog_LM_Q3_Storage]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = construction8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_spacecraftAdapter]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = construction8
 
@@ -6636,6 +6764,21 @@
 	@TechRequired = science5
 
 }
+@PART[bluedog_Surveyor_AlphaSpectrometer]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science5
+
+}
+@PART[bluedog_Surveyor_Camera]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science5
+
+}
+@PART[bluedog_Surveyor_Scoop]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science5
+
+}
 
 //Tier 6 
 @PART[bluedog_Mariner3_TV_Camera*]:AFTER[Bluedog_DB] //
@@ -7068,8 +7211,78 @@
 	@TechRequired = science8
 
 }
+@PART[bluedog_voyagerMarsLander_boomSampler]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsLander_camera]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsLander_drill]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsLander_passiveAirSampler]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsLander_radarAltimeter]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsLander_longRangeSampler]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_atmosphericMassSpec]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_cosmicRay]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_mmImpact]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_neutronAlbedoBoom]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_PSP]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_solarPlasma]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_solarXray]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science8
+
+}
 
 //Tier 9 science9
+@PART[bluedog_voyagerMarsOrbiter_PSP_upgrade]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = science9
+
+}
 @PART[bluedog_Skylab_EOSS_scatterometer]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = science9

--- a/ModSupport/Bluedog_DB/Bluedog_DB.cfg
+++ b/ModSupport/Bluedog_DB/Bluedog_DB.cfg
@@ -1629,129 +1629,128 @@
 	@TechRequired = landing6
 
 }
-
-//Tier 7 landing7
 @PART[bluedog_BigG_DrogueChute]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing7
+	@TechRequired = landing6
 
 }
 @PART[bluedog_BigG_MainParachute]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing7
+	@TechRequired = landing6
 
 }
 
 @PART[bluedog_Gemini_Heatshield_2p5m]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing7
+	@TechRequired = landing6
 
 }
 @PART[bluedog_Gemini_Heatshield_B]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing7
+	@TechRequired = landing6
 
 }
 @PART[bluedog_Gemini_Lander_Leg]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing7
+	@TechRequired = landing6
 
 }
 @PART[bluedog_Gemini_LanderCan]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing7
+	@TechRequired = landing6
 
 }
 @PART[bluedog_Hexagon_Mk8_Capsule]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing7
+	@TechRequired = landing6
 
 }
 @PART[bluedog_Hexagon_Mk8_Heatshield]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing7
+	@TechRequired = landing6
 
 }
 @PART[bluedog_Hexagon_Mk8_Parachute]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing6
+
+}
+//Tier 7 landing7
+@PART[bluedog_Apollo_Feetshield]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing7
+
+}
+
+@PART[bluedog_Apollo_Block2_Heatshield]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing7
+
+}
+@PART[bluedog_Apollo_Block2_Parachute]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing7
+
+}
+@PART[bluedog_LEM_Ascent_Cockpit]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing7
+
+}
+@PART[bluedog_LEM_Descent_Tanks]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing7
+
+}
+@PART[bluedog_Apollo_DrogueChute]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing7
+
+}
+@PART[bluedog_Apollo_Heatshield]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing7
+
+}
+@PART[bluedog_Apollo_MainChute]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing7
+
+}
+@PART[bluedog_LM_Ascent_Cockpit]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing7
+
+}
+@PART[bluedog_LM_Descent_Leg]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing7
+
+}
+@PART[bluedog_LM_Descent_Separator]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing7
+
+}
+@PART[bluedog_LM_Descent_Tanks]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = landing7
 
 }
 
 //Tier 8 landing8
-@PART[bluedog_Apollo_Feetshield]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S1D_Parachute]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = landing8
 
 }
-
-@PART[bluedog_Apollo_Block2_Heatshield]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing8
-
-}
-@PART[bluedog_Apollo_Block2_Parachute]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing8
-
-}
-@PART[bluedog_LEM_Ascent_Cockpit]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing8
-
-}
-@PART[bluedog_LEM_Descent_Tanks]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing8
-
-}
-@PART[bluedog_Apollo_DrogueChute]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing8
-
-}
-@PART[bluedog_Apollo_Heatshield]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing8
-
-}
-@PART[bluedog_Apollo_MainChute]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing8
-
-}
-@PART[bluedog_LM_Ascent_Cockpit]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing8
-
-}
-@PART[bluedog_LM_Descent_Leg]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing8
-
-}
-@PART[bluedog_LM_Descent_Separator]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing8
-
-}
-@PART[bluedog_LM_Descent_Tanks]:AFTER[Bluedog_DB] //
+@PART[bluedog_Skylab_VFB_entryProbe]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = landing8
 
 }
 
 //Tier 9 landing9
-@PART[bluedog_Saturn_S1D_Parachute]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing9
-
-}
-@PART[bluedog_Skylab_VFB_entryProbe]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = landing9
-
-}
 
 //Tier 10 landing10
 
@@ -2914,560 +2913,562 @@
 	@TechRequired = kerolox1
 
 }
-//Tier 2 tanks2
 @PART[bluedog_Vanguard_S2_Tank]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = tanks2
+	@TechRequired = kerolox1
 
 }
 @PART[bluedog_Redstone_FuelTank]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = tanks2
+	@TechRequired = kerolox1
 
 }
 @PART[bluedog_Redstone_MediumFuelTank]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = tanks2
+	@TechRequired = kerolox1
 
 }
 @PART[bluedog_Redstone_ShortFuelTank]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = tanks2
+	@TechRequired = kerolox1
 
 }
 @PART[bluedog_Vanguard_S1_Tank]:AFTER[Bluedog_DB]:NEEDS[RestockPlus] //
+{
+	@TechRequired = kerolox1
+
+}
+
+//Tier 2 tanks2
+@PART[bluedog_Ablestar_Tank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Delta2_LowerTank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_DeltaB_Tank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Juno4_FuelTank_1]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Juno4_FuelTank_2]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Jupiter_FuelTank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Mono_SmallSingle]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Mono_SmallTriple]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Thor_1p25mAdapter_Long]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Thor_1p25mAdapter_Medium]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Thor_LowerTank_1]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Thor_MediumExtensionTank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Thor_ShortExtensionTank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Thor_UpperTank_1]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_ThorAble_Tank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks2
+
+}
+@PART[bluedog_Agena_Tank_Short]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks2
 
 }
 
 //Tier 3 tanks3
-@PART[bluedog_Ablestar_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Atlas_AdapterFuelTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_Delta2_LowerTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Atlas_LongFuelTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_DeltaB_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Atlas_MediumFuelTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_Juno4_FuelTank_1]:AFTER[Bluedog_DB] //
+@PART[bluedog_Atlas_ShortAdapterTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_Juno4_FuelTank_2]:AFTER[Bluedog_DB] //
+@PART[bluedog_Atlas_ShortFuelTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_Jupiter_FuelTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Atlas_SustainerAdapterTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_Mono_SmallSingle]:AFTER[Bluedog_DB] //
+@PART[bluedog_DeltaE_Tank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_Mono_SmallTriple]:AFTER[Bluedog_DB] //
+@PART[bluedog_Mono_SphericalTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_Thor_1p25mAdapter_Long]:AFTER[Bluedog_DB] //
+@PART[bluedog_Titan1_S1_LowerTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_Thor_1p25mAdapter_Medium]:AFTER[Bluedog_DB] //
+@PART[bluedog_Titan1_S1_UpperTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_Thor_LowerTank_1]:AFTER[Bluedog_DB] //
+@PART[bluedog_Titan1_S2_ShortTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_Thor_MediumExtensionTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Titan1_S2_Tank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
-@PART[bluedog_Thor_ShortExtensionTank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks3
-
-}
-@PART[bluedog_Thor_UpperTank_1]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks3
-
-}
-@PART[bluedog_ThorAble_Tank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks3
-
-}
-@PART[bluedog_Agena_Tank_Short]:AFTER[Bluedog_DB] //
+@PART[bluedog_Agena_Tank_Long]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks3
 
 }
 
 //Tier 4 tanks4
-@PART[bluedog_Atlas_AdapterFuelTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CELV_AdapterTank_1p875m_Long]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_Atlas_LongFuelTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CELV_AdapterTank_1p875m_Short]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_Atlas_MediumFuelTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CELV_AdapterTank_2p5m_Long]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_Atlas_ShortAdapterTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CELV_AdapterTank_2p5m_Short]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_Atlas_ShortFuelTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CELV_LongTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_Atlas_SustainerAdapterTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CELV_MainTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_DeltaE_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CELV_MediumTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_Mono_SphericalTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CELV_ShortTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_Titan1_S1_LowerTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CELV_SustainerTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_Titan1_S1_UpperTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Centaur_Tank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_Titan1_S2_ShortTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CentaurD_FuelTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_Titan1_S2_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Delta2_UpperTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
-@PART[bluedog_Agena_Tank_Long]:AFTER[Bluedog_DB] //
+@PART[bluedog_DeltaP_Stage]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks4
+
+}
+@PART[bluedog_HOSS_Tank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks4
+
+}
+@PART[bluedog_Titan2_S1_Lower_Tank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks4
+
+}
+@PART[bluedog_Titan2_S1_Upper_Tank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks4
+
+}
+@PART[bluedog_Titan2_S2_Tank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks4
+
+}
+@PART[bluedog_Vega_Tank1]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks4
+
+}
+@PART[bluedog_Vega_Tank2]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks4
+
+}
+@PART[bluedog_Vega_ThirdStage_Tank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks4
 
 }
 
 //Tier 5 tanks5
-@PART[bluedog_CELV_AdapterTank_1p875m_Long]:AFTER[Bluedog_DB] //
+@PART[bluedog_Centaur4_Tank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_CELV_AdapterTank_1p875m_Short]:AFTER[Bluedog_DB] //
+@PART[bluedog_DCSS_Tank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_CELV_AdapterTank_2p5m_Long]:AFTER[Bluedog_DB] //
+@PART[bluedog_Delta3_AdapterTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_CELV_AdapterTank_2p5m_Short]:AFTER[Bluedog_DB] //
+@PART[bluedog_DeltaIII_AdapterTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_CELV_LongTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_DeltaK_Stage]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_CELV_MainTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_LDC_S1_Tank1]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_CELV_MediumTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_LDC_S1_Tank2]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_CELV_ShortTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_LDC_S2_Tank1]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_CELV_SustainerTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_LDC_S2_Tank2]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_Centaur_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_SLV3X_LowerTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_CentaurD_FuelTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_SLV3X_MainTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_Delta2_UpperTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_SLV3X_MediumTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_DeltaP_Stage]:AFTER[Bluedog_DB] //
+@PART[bluedog_SLV3X_ShortTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_HOSS_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_SLV3X_UpperTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
-@PART[bluedog_Titan2_S1_Lower_Tank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks5
-
-}
-@PART[bluedog_Titan2_S1_Upper_Tank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks5
-
-}
-@PART[bluedog_Titan2_S2_Tank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks5
-
-}
-@PART[bluedog_Vega_Tank1]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks5
-
-}
-@PART[bluedog_Vega_Tank2]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks5
-
-}
-@PART[bluedog_Vega_ThirdStage_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Titan3_S1_Stretched_Tank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks5
 
 }
 
 //Tier 6 tanks6
-@PART[bluedog_Centaur4_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Agena_SOT_1p875m]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_DCSS_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Agena_SOT_2p5m]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_Delta3_AdapterTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CentaurT_AdapterTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_DeltaIII_AdapterTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CentaurT_ShortTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_DeltaK_Stage]:AFTER[Bluedog_DB] //
+@PART[bluedog_CentaurT_TankA]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_LDC_S1_Tank1]:AFTER[Bluedog_DB] //
+@PART[bluedog_CentaurT_TankB]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_LDC_S1_Tank2]:AFTER[Bluedog_DB] //
+@PART[bluedog_CentaurT_TankC]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_LDC_S2_Tank1]:AFTER[Bluedog_DB] //
+@PART[bluedog_CentaurT_TankD]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_LDC_S2_Tank2]:AFTER[Bluedog_DB] //
+@PART[bluedog_CentaurT_WideTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_SLV3X_LowerTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_CentaurV_Tank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_SLV3X_MainTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Gemini_ArrowSM]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_SLV3X_MediumTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Gemini_Lander_Frame]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_SLV3X_ShortTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Gemini_Lander_SaddleTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_SLV3X_UpperTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Hexagon_ServiceModule]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
-@PART[bluedog_Titan3_S1_Stretched_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Titan4_S1_Lower_Tank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks6
+
+}
+@PART[bluedog_Titan4_S2_Tank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks6
+
+}
+@PART[bluedog_Saturn_S4B_Tank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks6
+
+}
+@PART[bluedog_Saturn_S4_Tank]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = tanks6
+
+}
+@PART[bluedog_Saturn_S1_Tanks]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks6
 
 }
 
 //Tier 7 tanks7
-@PART[bluedog_Agena_SOT_1p875m]:AFTER[Bluedog_DB] //
+@PART[bluedog_AtlasV_CCBLowerTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_Agena_SOT_2p5m]:AFTER[Bluedog_DB] //
+@PART[bluedog_AtlasV_CCBUpperTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_CentaurT_AdapterTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_DeltaIV_DCSS_5m]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_CentaurT_ShortTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_DeltaIV_s1_lowerTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_CentaurT_TankA]:AFTER[Bluedog_DB] //
+@PART[bluedog_DeltaIV_s1_upperTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_CentaurT_TankB]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S1_Tankage]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_CentaurT_TankC]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S1C_Tankage]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_CentaurT_TankD]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S1E_Tankage]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_CentaurT_WideTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S1F_Tankage]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_CentaurV_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S4_AdapterTank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_Gemini_ArrowSM]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S4_Tankage]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_Gemini_Lander_Frame]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S4B_Tankage]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_Gemini_Lander_SaddleTank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S4C_Tankage]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_Hexagon_ServiceModule]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S1C_Tank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_Titan4_S1_Lower_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S2_Tank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
-@PART[bluedog_Titan4_S2_Tank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks7
-
-}
-@PART[bluedog_Saturn_S4B_Tank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks7
-
-}
-@PART[bluedog_Saturn_S4_Tank]:AFTER[Bluedog_DB] //
+@PART[bluedog_Saturn_S4F_Tank]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = tanks7
 
 }
 
 //Tier 8 tanks8
-@PART[bluedog_AtlasV_CCBLowerTank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_AtlasV_CCBUpperTank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_DeltaIV_DCSS_5m]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_DeltaIV_s1_lowerTank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_DeltaIV_s1_upperTank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_Saturn_S1_Tankage]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_Saturn_S1C_Tankage]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_Saturn_S1E_Tankage]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_Saturn_S1F_Tankage]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_Saturn_S4_AdapterTank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_Saturn_S4_Tankage]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_Saturn_S4B_Tankage]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_Saturn_S4C_Tankage]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_Saturn_S1C_Tank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_Saturn_S2_Tank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-@PART[bluedog_Saturn_S4F_Tank]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks8
-
-}
-//Tier 9 tanks9
 @PART[bluedog_Saturn_LRB_Tank]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = tanks9
+	@TechRequired = tanks8
 
 }
 @PART[bluedog_Saturn_S1D_BoosterSkirt]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = tanks9
+	@TechRequired = tanks8
 
 }
 @PART[bluedog_Saturn_S1D_SustainerTank]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = tanks9
+	@TechRequired = tanks8
 
 }
 @PART[bluedog_Saturn_S1E_Tank]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = tanks9
+	@TechRequired = tanks8
 
 }
-@PART[bluedog_Saturn_S1_Tanks]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = tanks9
 
-}
+//Tier 9 tanks9
 
 //Tier 10 tanks10
 
@@ -5804,111 +5805,124 @@
 	@TechRequired = capsules6 
 
 }
+
 @PART[bluedog_Gemini_DockingPort]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = capsules6 
 
 }
+
 @PART[bluedog_Gemini_Port_A]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = capsules6 
 
 }
-//Tier 7 capsules7
+
 @PART[bluedog_BigG_LES]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = capsules7 
+	@TechRequired = capsules6 
 
 }
+
 @PART[bluedog_BigG_Cabin]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = capsules7 
+	@TechRequired = capsules6 
 
 }
 
 @PART[bluedog_Gemini_RadarEvaluationPod]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = capsules7 
+	@TechRequired = capsules6 
 
 }
 
 @PART[bluedog_Gemini_RumbleSeat]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = capsules6 
+
+}
+
+//Tier 7 capsules7
+@PART[bluedog_Apollo_Boilerplate]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = capsules7
+
+}
+
+@PART[bluedog_Apollo_CrewPod]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = capsules7
+
+}
+
+@PART[bluedog_Apollo_LES]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = capsules7
+
+}
+
+@PART[bluedog_Apollo_Block2_Capsule]:AFTER[Bluedog_DB] //Old
+{
+	@TechRequired = capsules7 
+
+}
+
+@PART[bluedog_Apollo_Block2_LES]:AFTER[Bluedog_DB] //Old
+{
+	@TechRequired = capsules7 
+
+}
+
+@PART[bluedog_Apollo_Block2_ActiveDockingMechanism]:AFTER[Bluedog_DB] //Old
+{
+	@TechRequired = capsules7 
+
+}
+
+@PART[bluedog_Apollo_Block2_PassiveDockingMechanism]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = capsules7 
 
 }
 
 //Tier 8 capsules8
-@PART[bluedog_Apollo_Boilerplate]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = capsules8
-
-}
-@PART[bluedog_Apollo_CrewPod]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = capsules8
-
-}
-@PART[bluedog_Apollo_LES]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = capsules8
-
-}
-@PART[bluedog_Apollo_Block2_Capsule]:AFTER[Bluedog_DB] //Old
-{
-	@TechRequired = capsules8 
-
-}
-
-@PART[bluedog_Apollo_Block2_LES]:AFTER[Bluedog_DB] //Old
-{
-	@TechRequired = capsules8 
-
-}
-@PART[bluedog_Apollo_Block2_ActiveDockingMechanism]:AFTER[Bluedog_DB] //Old
-{
-	@TechRequired = capsules8 
-
-}
-
-@PART[bluedog_Apollo_Block2_PassiveDockingMechanism]:AFTER[Bluedog_DB] //
-{
-	@TechRequired = capsules8 
-
-}
-//Tier 9 capsules9
 @PART[bluedog_Apollo_Block3_Capsule]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = capsules9 
+	@TechRequired = capsules8 
+	
 }
 
 @PART[bluedog_Apollo_Block4_MissionModule]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = capsules9 
+	@TechRequired = capsules8 
 
 }
 
 @PART[bluedog_Saturn_VFB_MissionModule]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = capsules9 
+	@TechRequired = capsules8 
 
 }
+
 @PART[bluedog_Apollo_Block3_MissionModule]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = capsules9
+	@TechRequired = capsules8
 
 }
+
 @PART[bluedog_Skylab_VFB_ESM]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = capsules9
+	@TechRequired = capsules8
 
 }
+
 @PART[bluedog_Apollo_CrewPod_5crew]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = capsules9
+	@TechRequired = capsules8
 
 }
 
+//Tier 9 capsules9
 
 //Tier 10 capsules10
 
@@ -7066,7 +7080,7 @@
 }
 @PART[bluedog_LM_Lab]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing9
+	@TechRequired = landing8
 
 }
 @PART[bluedog_LM_Lab_Battery]:AFTER[Bluedog_DB] //
@@ -7096,12 +7110,12 @@
 }
 @PART[bluedog_LM_Shelter]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing9
+	@TechRequired = landing8
 
 }
 @PART[bluedog_LM_Taxi]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing9
+	@TechRequired = landing8
 
 }
 @PART[bluedog_LM_Truck_Platform]:AFTER[Bluedog_DB] //
@@ -7151,7 +7165,7 @@
 }
 @PART[bluedog_Centaur_Kickstage]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = tanks6
+	@TechRequired = tanks5
 
 }
 @PART[bluedog_saturn_h03_SLAbase]:AFTER[Bluedog_DB] //
@@ -7172,7 +7186,7 @@
 
 @PART[bluedog_LM_LunarFlyingVehicle]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = capsules9
+	@TechRequired = capsules8
 
 }
 @PART[bluedog_Centaur_FairingBase4xx_SAF]:AFTER[Bluedog_DB] //
@@ -7182,7 +7196,7 @@
 }
 @PART[bluedog_Saturn_S2_wetWorkshop]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = tanks9
+	@TechRequired = tanks8
 
 }
 @PART[bluedog_Skylab_dockingNodeAdapter]:AFTER[Bluedog_DB] //
@@ -7268,7 +7282,7 @@
 }
 @PART[bluedog_EarlyLunarShelter]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing9
+	@TechRequired = landing8
 
 }
 @PART[bluedog_EarlyLunarShelter_Telescope]:AFTER[Bluedog_DB] //
@@ -7278,7 +7292,7 @@
 }
 @PART[bluedog_LM_Descent_Tanks_Truck]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing9
+	@TechRequired = landing8
 
 }
 @PART[bluedog_LM_DrillExperiment]:AFTER[Bluedog_DB] //
@@ -7298,7 +7312,7 @@
 }
 @PART[bluedog_LM_SheLab]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing9
+	@TechRequired = landing8
 
 }
 @PART[bluedog_LM_SheLab_Spotlight]:AFTER[Bluedog_DB] //
@@ -7333,12 +7347,12 @@
 }
 @PART[bluedog_LRV_Base_Combined]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing8
+	@TechRequired = landing7
 
 }
 @PART[bluedog_LTV]:AFTER[Bluedog_DB] //
 {
-	@TechRequired = landing9
+	@TechRequired = landing8
 
 }
 @PART[bluedog_BigG_Adapter]:AFTER[Bluedog_DB] //

--- a/ModSupport/Bluedog_DB/Bluedog_DB.cfg
+++ b/ModSupport/Bluedog_DB/Bluedog_DB.cfg
@@ -1525,6 +1525,21 @@
 }
 
 //Tier 9 probes9
+@PART[bluedog_voyagerMarsLander_core]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = probes8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_core]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = probes8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_propulsionModule]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = probes8
+
+}
 
 //Tier 10 probes10
 
@@ -1745,6 +1760,45 @@
 
 }
 @PART[bluedog_Skylab_VFB_entryProbe]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing8
+
+}
+@PART[bluedog_C1engine]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing8
+
+}
+@PART[bluedog_voyagerMarsLander_descentEngine]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing8
+
+}
+@PART[bluedog_voyagerMarsLander_leg]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing8
+
+}
+@PART[bluedog_voyagerMarsLander_srbMount]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing8
+
+}
+@PART[bluedog_voyagerMarsLander_parachute]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing8
+
+}
+@PART[bluedog_voyagerMarsLander_parachute]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing8
+
+}
+@PART[bluedog_voyagerMarsOrbiter_backshell]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = landing8
+
+}@PART[bluedog_voyagerMarsOrbiter_heatshield]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = landing8
 

--- a/ModSupport/WildBlueIndustries/WildBlueIndustries.cfg
+++ b/ModSupport/WildBlueIndustries/WildBlueIndustries.cfg
@@ -81,108 +81,108 @@
 
 //Tier 9 aerodynamics9
 
+//Tier 10 aerodynamics10
+
 @PART[Mk33BodyFlap]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[Mk33InnerElevon]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[Mk33NoseCone]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 	
 }
 @PART[Mk33OuterElevon]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[Mk33Tailfin]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[Mk33Wing]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[Mk33Cockpit]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[Mk33ProbeCore]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[Mk33DockingNoseCone]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[mk33AeroCone]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[mk33EngineCoupler]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[mk33EngineCoupler2]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[mk33EngineCoupler4]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[Mk33AftTank]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[Mk33FwdTank]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[Mk33MidTank]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[wbiMk33CargoModule]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[wbiMk33KrewModule]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[wbiMk33FuelModule]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
 @PART[wbiMk33CargoBay]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics9
+	@TechRequired = aerodynamics10
 
 }
-
-//Tier 10 aerodynamics10
 
 //Tier 11 aerodynamics11
 
@@ -250,13 +250,14 @@
 //Tier 8 control8
 
 //Tier 9 control9
-@PART[wbiMk33RCSPod]:AFTER[WildBlueIndustries] //
-{
-	@TechRequired = control9
-
-}
 
 //Tier 10 control10
+
+@PART[wbiMk33RCSPod]:AFTER[WildBlueIndustries] //
+{
+	@TechRequired = control10
+
+}
 
 //Tier 11 control11
 
@@ -303,23 +304,24 @@
 //Tier 8 landing8
 
 //Tier 9 landing9
+
+//Tier 10 landing10
+
 @PART[wbiMk33MainGear]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = landing9
+	@TechRequired = landing10
 
 }
 @PART[wbiMk33NoseGear]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = landing9
+	@TechRequired = landing10
 
 }
 @PART[wbiPostWheel]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = landing9
+	@TechRequired = landing10
 
 }
-
-//Tier 10 landing10
 
 //Tier 11 landing11
 
@@ -426,13 +428,14 @@
 //Tier 8 cryo8
 
 //Tier 9 cryo9
-@PART[KR2200L]:AFTER[WildBlueIndustries] //
-{
-	@TechRequired = cryo9
-
-}
 
 //Tier 10 cryo10
+
+@PART[KR2200L]:AFTER[WildBlueIndustries] //
+{
+	@TechRequired = cryo10
+
+}
 
 //Tier 11 cryo11
 
@@ -685,58 +688,59 @@
 //Tier 8 construction8
 
 //Tier 9 construction9
+
+//Tier 10 construction10
+
 @PART[wbiControlCab]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction9
+	@TechRequired = construction10
 
 }
 @PART[mk33CrewTowerBase]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction9
+	@TechRequired = construction10
 
 }
 @PART[mk33CrewTowerCockpitSection]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction9
+	@TechRequired = construction10
 
 }
 @PART[mk33CrewTowerMidSection]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction9
+	@TechRequired = construction10
 
 }
 @PART[mk33DockingPiston]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction9
+	@TechRequired = construction10
 
 }
 @PART[mk33LaunchPlatform]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction9
+	@TechRequired = construction10
 	
 }
 @PART[mk33PayloadCrane]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction9
+	@TechRequired = construction10
 
 }
 @PART[mk33PlatformElevator]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction9
+	@TechRequired = construction10
 
 }
 @PART[mk33Strongback]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction9
+	@TechRequired = construction10
 
 }
 @PART[wbiMk33Airlock]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction9
+	@TechRequired = construction10
 
 }
-
-//Tier 10 construction10
 
 //Tier 11 construction11
 

--- a/ModSupport/shuttle_OV200/shuttle_OV200.cfg
+++ b/ModSupport/shuttle_OV200/shuttle_OV200.cfg
@@ -1,0 +1,690 @@
+//Tiers
+Tier 0 - Starting Gear - basic low atmospheric sounding rockets - may be merged with tier 1
+Tier 1 - Sounding Rockets - Capable of reaching space, along with the first introduction of Kerolox
+Tier 2 - Early Orbital Rockets - think Sputnik, Vangaurd, Scout, and Redstone/Explorer 1 - probes like Sputnik and Explorer 1 - 1.25m parts
+Tier 3 - Improved Orbital Rockets - think Thor, Juno II, Agena A, etc - basic orbital research and comms sats - 1.5m parts
+Tier 4 - Mature Orbital Rockets - Advanced Thor, Agena B, Delta E and F, and early 1.875 rockets like Atlas and Agena - probes focus on the Ranger missions to the Moon/Mun&Minmus
+Tier 5 - High-Performance Rockets - Atlas, Titan II, Centaur, Delta II, Agena D, Mercury - 2.5 parts introduction - probes including Mariner and Verena, and the Surveyor Moon landers
+Tier 6 - Medium-Lift Rockets - Delta III, Titan III, LDC, Atlas CELV, Gemini, First Space Stations - 3.125m parts - probes include more advanced mariners, pioneer 10/11, the first atmospheric landers (Viking anyone?) and many orbiters
+Tier 7 - Heavy-Lift Rockets - Saturn I/C, Delta IV, Atlas V, Titan IV, Big G, MOL Agena SOT - 3.75m parts - probes include Voyager and RoveMate gear
+Tier 8 - Super Heavy-Lift Rockets - Saturn V, Space Shuttle, Apollo LEM, Skylab - 5m parts - probes like Cassini and other advanced probes
+Tier 9 - Modern Rockets - Advanced Saturn Variants, Apollo Blks 3-5, VFB, Falcon 9/Heavy, Space Launch System, Vulcan, Ares I/V, Orion, Starliner, Crew/Cargo Dragon, Cygnus - modern probe missions like Juno and New Horizons
+Tier 10 - Near Future Rocketry - Advanced "game changer" rockets - Starship/BFS, New Glenn, etc - 7.5m parts - near future probe missions like Europa Clipper
+Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous parts - also SpaceY 10m tankage - AI?
+
+
+/////////////////////////
+/////Aviation Branch/////
+/////////////////////////
+
+/////Spaceplanes (Turbojets, Scramjets, Ramjets, MultiMode Engines, Atomic Jets, etc) (spaceplanes#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 spaceplanes4
+
+//Tier 5 spaceplanes5
+
+//Tier 6 spaceplanes6
+
+//Tier 7 spaceplanes7
+
+//Tier 9 spaceplanes9
+@PART[pathfinder_nerva_main_engine]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = spaceplanes9
+
+}
+@PART[SaberEngine]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = spaceplanes9
+
+}
+
+//Tier 11 spaceplanes11
+
+/////Aerodynamics (Most Fuselages and Fueltanks, general aviation parts, wings) (aerodynamics#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 aerodynamics4
+
+//Tier 5 aerodynamics5
+
+//Tier 6 aerodynamics6
+
+//Tier 7 aerodynamics7
+
+//Tier 8 aerodynamics8
+
+//Tier 9 aerodynamics9
+@PART[pathfinder_shuttle_adapter]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = aerodynamics9
+
+}
+@PART[pathfinder_shuttle_aftFuselage]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = aerodynamics9
+
+}
+@PART[pathfinder_shuttle_deltaWing]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = aerodynamics9
+
+}
+@PART[pathfinder_shuttle_elevon1]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = aerodynamics9
+
+}
+@PART[pathfinder_shuttle_elevon2]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = aerodynamics9
+
+}
+@PART[pathfinder_shuttle_forwardFuselage]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = aerodynamics9
+
+}
+@PART[pathfinder_shuttle_mainGear]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = aerodynamics9
+
+}
+@PART[pathfinder_shuttle_midFuselage]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = aerodynamics9
+
+}
+@PART[pathfinder_shuttle_noseGear]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = aerodynamics9
+
+}
+@PART[pathfinder_shuttle_rudder]:AFTER[shuttle_OV200] //
+{
+	@TechRequired = aerodynamics9
+
+}
+
+//Tier 10 aerodynamics10
+
+//Tier 11 aerodynamics11
+
+/////Commercial Aerodynamics (Turbofan Engines, Passenger Modules, Plane Landing Gear, FAT-455 parts) (aviation#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aviation2
+
+//Tier 3 aviation3
+
+//Tier 4 aviation4
+
+//Tier 5 aviation5
+
+//Tier 6 aviation6
+
+//Tier 7 aviation7
+
+
+////////////////////////
+/////Control Branch/////
+////////////////////////
+
+/////Communications (Antennae) (comms#)
+
+//Tier 1 control1
+
+//Tier 2 comms2
+
+//Tier 3 comms3
+
+//Tier 4 comms4
+
+//Tier 5 comms5
+
+//Tier 6 comms6
+
+//Tier 7 comms7
+
+//Tier 8 comms8
+
+//Tier 9 comms9
+
+//Tier 10 comms10
+
+//Tier 11 comms11
+
+/////Control (Reaction Wheels, RCS Thrusters, Drone Cores) (control#)
+
+//Tier 1 control1
+
+//Tier 2 control2
+
+//Tier 3 control3
+
+//Tier 4 control4
+
+//Tier 5 control5
+
+//Tier 6 control6
+
+//Tier 7 control7
+
+//Tier 8 control8
+
+//Tier 9 control9
+
+//Tier 10 control10
+
+//Tier 11 control11
+
+//////Probe Cores (probes#)
+
+//Tier 1 control1
+
+//Tier 2 probes2
+
+//Tier 3 probes3
+
+//Tier 4 probes4
+
+//Tier 5 probes5
+
+//Tier 6 probes6
+
+//Tier 7 probes7
+
+//Tier 8 probes8
+
+//Tier 9 probes9
+
+//Tier 10 probes10
+
+//Tier 11 probes11
+
+//////Landing (Landing Legs, Heat Shields, Parachutes)  (landing#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 landing9
+
+//Tier 10 landing10
+
+//Tier 11 landing11
+
+//////Reusability (Falcon 9/New Glenn/Starship Style Landing Legs, SMART Reuse, Booster Wings, etc)  (reuse#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 reuse9
+
+//Tier 10 reuse10
+
+//Tier 11 landing11
+
+//////Robotics (Breaking Ground Robotics, Rover Parts)  (robotics#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 robotics6
+
+//Tier 7 robotics7
+
+//Tier 8 robotics8
+
+//Tier 9 robotics9
+
+//Tier 10 robotics10
+
+//Tier 11 probes11
+
+///////////////////////////
+/////Propulsion Branch/////
+///////////////////////////
+
+//////Solid Rocket Boosters  (solids#)
+
+//Tier 1 solids1
+
+//Tier 2 solids2
+
+//Tier 3 solids3
+
+//Tier 4 solids4
+
+//Tier 5 solids5
+
+//Tier 6 solids6
+
+//Tier 7 solids7
+
+//Tier 8 solids8
+
+//Tier 9 solids9
+
+//Tier 10 solids10
+
+//Tier 11 solids11
+
+//////Cryogenic Rocket Engines (LH2 and CH4 Engines)  (cryo#)
+
+//Tier 1 kerolox1
+
+//Tier 2 cryo2
+
+//Tier 3 cryo3
+
+//Tier 4 cryo4
+
+//Tier 5 cryo5
+
+//Tier 6 cryo6
+
+//Tier 7 cryo7
+
+//Tier 8 cryo8
+
+//Tier 9 cryo9
+
+//Tier 10 cryo10
+
+//Tier 11 cryo11
+
+//////Kerlox Rocket Engines (Liquid Fuel/RP-1 Engines, with a focus on Lifters)  (kerolox#)
+
+//Tier 1 kerolox1
+
+//Tier 2 kerolox2
+
+//Tier 3 kerolox3
+
+//Tier 4 kerolox4
+
+//Tier 5 kerolox5
+
+//Tier 6 kerolox6
+
+//Tier 7 kerolox7
+
+//Tier 8 kerolox8
+
+//Tier 9 kerolox9
+
+//Tier 10 kerolox10
+
+//Tier 11 kerolox11
+
+//Tier 12 kerolox12
+
+//////Hypergolic Rocket Engines (Upper Stage Engines (mainly those which really use hypergolics) - may use real hypergolics with Clamp-o-Tron's More Fuels)  (hypergol#)
+
+//Tier 1 kerolox1
+
+//Tier 2 hypergol2
+
+//Tier 3 hypergol3
+
+//Tier 4 hypergol4
+
+//Tier 5 hypergol5
+
+//Tier 6 hypergol6
+
+//Tier 7 hypergol7
+
+//Tier 8 hypergol8
+
+//Tier 9 hypergol9
+
+//Tier 10 hypergol10
+
+//Tier 11 hypergol11
+
+//////Conventional Fuel Tanks (tanks#)
+
+//Tier 1 kerolox1
+
+//Tier 2 tanks2
+
+//Tier 3 tanks3
+
+//Tier 4 tanks4
+
+//Tier 5 tanks5
+
+//Tier 6 tanks6
+
+//Tier 7 tanks7
+
+//Tier 8 tanks8
+
+//Tier 9 tanks9
+
+//Tier 10 tanks10
+
+//Tier 11 tanks11
+
+
+////////////////////////////////
+/////Nuclear/Exotics Branch/////
+////////////////////////////////
+
+//////Nuclear Rockets (Both Fission and Fusion) (ntr#)
+
+//Tier 8 reactors8
+
+//Tier 9 ntr9
+
+//Tier 10 ntr10
+
+//Tier 11 ntr11
+
+//Tier 12 ntr12
+
+//Tier 13 ntr13
+
+//Tier 14 ntr14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Nuclear Reactors (Both Fission and Fusion) (reactors#)
+
+//Tier 5 reactors5
+
+//Tier 6 reactors6
+
+//Tier 7 reactors7
+
+//Tier 8 reactors8
+
+//Tier 9 reactors9
+
+//Tier 10 reactors10
+
+//Tier 11 reactors11
+
+//Tier 12 reactors12
+
+//Tier 13 reactors13
+
+//Tier 14 reactors14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Faster Than Light (ftl#)
+
+//Tier 16 ftl16
+
+//Electromagnetic Propulsion (Xenon/Argon Thrusters) (ion#)
+
+//Tier 6 ion6
+
+//Tier 7 ion7
+
+//Tier 8 ion8
+
+//Tier 9 ion9
+
+//Tier 10 ion10
+
+//Tier 11 ion11
+
+//Exotic Propulsion (Plasma/Lithium/Antimatter) (plasma#)
+
+//Tier 10 plasma10
+
+//Tier 11 plasma11
+
+//Tier 12 plasma12
+
+//Tier 13 plasma13
+
+//Tier 14 plasma14
+
+//Tier 15 plasma15
+
+//Tier 16 plasma16
+
+
+//////////////////////////
+/////Electrics Branch/////
+//////////////////////////
+
+//////Electrics (Batteries, Capacitors, and Fuel Cells)  (electrics#)
+
+//Tier 1 electrics1
+
+//Tier 2 electrics2
+
+//Tier 3 electrics3
+
+//Tier 4 electrics4
+
+//Tier 5 electrics5
+
+//Tier 6 electrics6
+
+//Tier 7 electrics7
+
+//Tier 8 electrics8
+
+//Tier 9 electrics9
+
+//Tier 10 electrics10
+
+//Tier 11 electrics11
+
+//Tier 12 electrics12
+
+///// Solar Panels (and technically solar sails too) (solar#)
+
+//Tier 3 solar3
+
+//Tier 4 solar4
+
+//Tier 5 solar5
+
+//Tier 6 solar6
+
+//Tier 7 solar7
+
+//Tier 8 solar8
+
+//Tier 9 solar9
+
+//Tier 10 solar10
+
+//Tier 11 solar11
+
+//Tier 12 solar12
+
+//////Thermal - Radiators and Heat Management Systems  (thermal#)
+
+//Tier 5 thermal5
+
+//Tier 6 thermal6
+
+//Tier 7 thermal7
+
+//Tier 8 thermal8
+
+//Tier 9 thermal9
+
+//Tier 10 thermal10
+
+//Tier 11 thermal11
+
+//Tier 12 thermal12
+
+//////////////////////////////////////////////////////////////////
+/////Construction/Logistics/Science/Manned Spaceflight Branch/////
+//////////////////////////////////////////////////////////////////
+
+//////Construction (Adapters, Nosecones, Decouplers, Engine Plates/Mounts, Trusses, etc  (construction#)
+
+//Tier 1 construction1
+
+//Tier 2 construction2
+
+//Tier 3 construction3
+
+//Tier 4 construction4
+
+//Tier 5 construction5
+
+//Tier 6 construction6
+
+//Tier 7 construction7
+
+//Tier 8 construction8
+
+//Tier 9 construction9
+
+//Tier 10 construction10
+
+//Tier 11 construction11
+
+//Tier 12 construction12
+
+//////ISRU (Resource Miners and Converters) (isru#)
+
+//Tier 9 isru9
+
+//Tier 10 isru10
+
+//Tier 11 isru11
+
+//Tier 12 isru12
+
+//////Logistics and Life-Support (Resource Storage, Life-Support Modules, Containers, etc)  (logistics#)
+
+//Tier 6 logistics6
+
+//Tier 7 logistics7
+
+//Tier 8 logistics8
+
+//Tier 9 logistics9
+
+//Tier 10 logistics10
+
+//Tier 11 logistics11
+
+//////Manned Spacecraft, Command Modules (except landers), and Launch Escape Systems  (capsules#)
+
+//Tier 5 capsules5
+
+//Tier 6 capsules6
+
+//Tier 7 capsules7
+
+//Tier 8 capsules8
+
+//Tier 9 capsules9
+
+//Tier 10 capsules10
+
+//Tier 11 capsules11
+
+//////Space Station Parts (Both Structural and Crewed)  (spaceStations#)
+
+//Tier 6 spaceStations6
+
+//Tier 7 spaceStations7
+
+//Tier 8 spaceStations8
+
+//Tier 9 spaceStations9
+
+//Tier 10 spaceStations10
+
+//Tier 11 spaceStations11
+
+
+//////Planetary Bases (Both structural and crewed) (bases#)
+
+//Tier 9 bases9
+
+//Tier 10 bases10
+
+//Tier 11 bases11
+
+//Tier 12 bases12
+
+//////Science Equipment, SCANSAT scanners (resource ones go in ISRU), and the like (Labs go in stations however) (science#)
+
+//Tier 1 construction1
+
+//Tier 2 science2
+
+//Tier 3 science3
+
+//Tier 4 science4
+
+//Tier 5 science5
+
+//Tier 6 science6
+
+//Tier 7 science7
+
+//Tier 8 science8
+
+//Tier 9 science9
+
+//Tier 10 science10
+
+//Tier 11 science11
+
+//Tier 12 science12

--- a/Patches/Control/SASUpgrades.cfg
+++ b/Patches/Control/SASUpgrades.cfg
@@ -36,7 +36,7 @@
 		
 	}
 }
-@PART[*]:HAS[!MODULE[ModuleCommand]]:FOR[zzzSkyhawkScienceSystem]
+@PART[*]:HAS[@MODULE[ModuleSAS],!MODULE[ModuleCommand]]:FOR[zzzSkyhawkScienceSystem]
 {
 	!MODULE[ModuleSAS] {} // Remove original SAS Module
 	MODULE


### PR DESCRIPTION
Adds parts from S.P.O.C.K. Which is a mod that adds parts to make the Pathfinder shuttle from the 2nd season of For All Mankind. Basically, follows the Shuttle Orbiter Construction Kit in the tech-tree.